### PR TITLE
 Fix chat message error when MoreCompany is not installed

### DIFF
--- a/CosmeticPatch.cs
+++ b/CosmeticPatch.cs
@@ -5,6 +5,7 @@ using MoreCompany.Cosmetics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -18,20 +19,27 @@ namespace MirrorDecor
         {
             if (Chainloader.PluginInfos.ContainsKey("me.swipez.melonloader.morecompany"))
             {
-                CosmeticApplication app = GameObject.FindObjectOfType<CosmeticApplication>();
+                MoreCompanyPatch();
+            }
+        }
 
-                if (CosmeticRegistry.locallySelectedCosmetics.Count > 0 && app.spawnedCosmetics.Count <= 0)
+        // seperate method without inlining to avoid throwing errors on chat message
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void MoreCompanyPatch()
+        {
+            CosmeticApplication app = GameObject.FindObjectOfType<CosmeticApplication>();
+
+            if (CosmeticRegistry.locallySelectedCosmetics.Count > 0 && app.spawnedCosmetics.Count <= 0)
+            {
+                foreach (string id in CosmeticRegistry.locallySelectedCosmetics)
                 {
-                    foreach (string id in CosmeticRegistry.locallySelectedCosmetics)
-                    {
-                        app.ApplyCosmetic(id, true);
-                    }
+                    app.ApplyCosmetic(id, true);
+                }
 
-                    foreach (CosmeticInstance instance in app.spawnedCosmetics)
-                    {
-                        instance.transform.localScale *= 0.38f;
-                        SetAllChildrenLayer(instance.transform, 29);
-                    }
+                foreach (CosmeticInstance instance in app.spawnedCosmetics)
+                {
+                    instance.transform.localScale *= 0.38f;
+                    SetAllChildrenLayer(instance.transform, 29);
                 }
             }
         }


### PR DESCRIPTION
Right now, every chat message will lag the game if you don't have MoreCompany installed

```cs
[Error  : Unity Log] FileNotFoundException: Could not load file or assembly 'MoreCompany, Version=1.7.2.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
Stack trace:
(wrapper dynamic-method) HUDManager.DMD<HUDManager::AddPlayerChatMessageClientRpc>(HUDManager,string,int)
HUDManager.__rpc_handler_168728662 (Unity.Netcode.NetworkBehaviour target, Unity.Netcode.FastBufferReader reader, Unity.Netcode.__RpcParams rpcParams) (at <44743d9474784365a095189c76175301>:IL_0073)
```

This should fix the error by moving the morecompany compatibility patch to a separate method without inlining 

This way it won't attempt to load the types/assembly unless it's 100% installed